### PR TITLE
Remove abs(float) function that clashes with std::abs(float)

### DIFF
--- a/handler.cc
+++ b/handler.cc
@@ -23,6 +23,8 @@
 #include <X11/extensions/XTest.h>
 #include <X11/XKBlib.h>
 #include <X11/Xproto.h>
+#include <cmath>  // std::abs(float)
+using std::abs;
 
 XState *xstate = nullptr;
 
@@ -532,8 +534,6 @@ public:
 	virtual std::string name() { return "WaitForPong"; }
 	virtual Grabber::State grab_mode() { return parent->grab_mode(); }
 };
-
-static inline float abs(float x) { return x > 0 ? x : -x; }
 
 class AbstractScrollHandler : public Handler {
 	bool have_x, have_y;


### PR DESCRIPTION
Depending on which C++ standard library headers have been included there
might an abs(float) function already declared in the global namespace,
so the definition in this file conflicts with it. This cause a build
failure with GCC 7, which conforms more closely to the C++ standard with
respect to overloads of abs.

Including <cmath> and adding a using-declaration for std::abs ensures
that the standard std::abs(float) function is available. This solution
should be portable to all compilers.