### PR TITLE
Fix call to deprecated GTK function

### DIFF
--- a/actions.cc
+++ b/actions.cc
@@ -23,6 +23,7 @@
 #include "grabber.h"
 #include "cellrenderertextish.h"
 
+#include <functional>
 #include <typeinfo>
 
 bool TreeViewMulti::on_button_press_event(GdkEventButton* event) {
@@ -54,7 +55,7 @@ void TreeViewMulti::on_drag_begin(const Glib::RefPtr<Gdk::DragContext> &context)
 bool negate(bool b) { return !b; }
 
 TreeViewMulti::TreeViewMulti() : Gtk::TreeView(), pending(false) {
-	get_selection()->set_select_function(sigc::group(&negate, sigc::ref(pending)));
+  get_selection()->set_select_function([this](const Glib::RefPtr<Gtk::TreeModel>&, const Gtk::TreePath&, const bool&) { return !this->pending; });
 }
 
 enum Type { COMMAND, KEY, TEXT, SCROLL, IGNORE, BUTTON, MISC };

--- a/handler.cc
+++ b/handler.cc
@@ -533,7 +533,6 @@ public:
 	virtual Grabber::State grab_mode() { return parent->grab_mode(); }
 };
 
-static inline float abs(float x) { return x > 0 ? x : -x; }
 
 class AbstractScrollHandler : public Handler {
 	bool have_x, have_y;


### PR DESCRIPTION
* Change from sigc::group (deprecated) to C++11 lambda
* Remove superflous `abs` definition that conflicted with libc/c++