### PR TITLE
Scaling factor fix

### DIFF
--- a/composite.cc
+++ b/composite.cc
@@ -17,6 +17,8 @@
 #include "composite.h"
 #include <gdkmm.h>
 #include <glibmm/i18n.h>
+#include <gdk/gdk.h>
+
 
 double red, green, blue, alpha, width;
 std::list<Trace::Point> points;
@@ -49,6 +51,9 @@ Composite::Composite() {
 #define N 128
 	int w = gdk_screen_width();
 	int h = gdk_screen_height();
+	GdkDisplay* dp = gdk_display_get_default();
+	GdkMonitor* mon = gdk_display_get_primary_monitor(dp);
+	scale_factor = gdk_monitor_get_scale_factor(mon);
 	num_x = (gdk_screen_width()  - 1)/N + 1;
 	num_y = (gdk_screen_height() - 1)/N + 1;
 	pieces = new Popup**[num_x];
@@ -61,6 +66,12 @@ Composite::Composite() {
 }
 
 void Composite::draw(Point p, Point q) {
+	if(scale_factor > 0) {
+		p.x /= scale_factor;
+		p.y /= scale_factor;
+		q.x /= scale_factor;
+		q.y /= scale_factor;
+	}
 	if (!points.size()) {
 		points.push_back(p);
 	}

--- a/composite.h
+++ b/composite.h
@@ -31,6 +31,7 @@ public:
 
 class Composite : public Trace {
 	int num_x, num_y;
+	int scale_factor;
 	Popup ***pieces;
 	virtual void draw(Point p, Point q);
 	virtual void start_();


### PR DESCRIPTION
See issue reported here: https://github.com/thjaeger/easystroke/pull/10#issuecomment-643974773

currently, this addresses the simplest case: one monitor, integer scaling, tested on Ubuntu 18.04, only with the "Default" method to display strokes (not with the "XShape" method)

TODO:
  -- do not use deprecated functions: gdk_screen_width(), gdk_screen_height()
  -- handle multiple monitors separately: this should be possible based on the GdkScreen and GdkMonitor API; it is unclear to me how to find out which monitor a point belongs to if GDK thinks in scaled coordinates
  -- handle fractional scaling: this seems complicated, the gdk_monitor_get_scale_factor() API returns an integer, maybe there is a different API that can return fractional scale

It would be great to have this tested more :)
